### PR TITLE
Update to 1.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passages (1.0.0)
+    passages (1.1.0)
       rails (~> 4.0)
 
 GEM

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 module Passages
   MAJOR = 1
-  MINOR = 0
+  MINOR = 1
   TINY = 0
 
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze


### PR DESCRIPTION
Automatic route mounting has been removed, it must now
  be either mounted manually or have the automount turned on
  in an intializer.

Basic auth is supported by uppercase and lowercase vars.